### PR TITLE
Add Obsidian Templates to `Assets/Wiki Templates`

### DIFF
--- a/content/Assets/Wiki Templates/Folder index.md template.md
+++ b/content/Assets/Wiki Templates/Folder index.md template.md
@@ -1,0 +1,12 @@
+---
+title:
+aliases:
+tags:
+description:
+---
+## (index subheading here)
+
+%% Populate the Properties %%
+%% Title and Aliases should contain the name of the folder that the index.md file belongs to %%
+%% Description property adds a description to this index file when it appears in another index's listings. Description should be concise and catchy %%
+%% Index subheading should match the 'description' field in properties %%

--- a/content/Assets/Wiki Templates/Guides Article template.md
+++ b/content/Assets/Wiki Templates/Guides Article template.md
@@ -1,0 +1,7 @@
+---
+tags:
+description:
+---
+
+%% Populate the tags in Properties %%
+%% Description property adds a description to this article when it appears in another index's listings. Description should be concise and catchy %%

--- a/content/Assets/Wiki Templates/Guides Tutorial template.md
+++ b/content/Assets/Wiki Templates/Guides Tutorial template.md
@@ -1,0 +1,29 @@
+---
+tags:
+description:
+---
+
+%% Populate the tags in Properties %%
+%% Description property adds a description to this article when it appears in another index's listings. Description should be concise and catchy %%
+
+%% Add a brief description of what the page does. It should be at the top of the article and text should be italicized %%
+	%% E.G. *This page contains three tutorials of varying difficulty on how to create an ESP Replacer Patch:* %%
+
+%% Add a backlink to any relevant Guides pages which provide background on the subject matter of the tutorial %%
+	%%* E.g. See [[Creating a Patch for an ESP]] for more information on what patches are and how they work.* %%
+
+# Tutorial 1: 
+%%![[Patches_ESP-Replacer_1_Preview.png]]%% %% add an introductory image or screenshot related to the tutorial  %%
+* **Difficulty level:** %% Beginner, Intermediate or Advanced %%
+* **Requirements:**
+     * %% list required tools %%
+* **Tutorial Files:**
+     * %%`your tutorial mod.esp`%%
+     * %% List any files created for the tutorials that users require in order to follow along with the tutorial, e.g. two ESPs for an ESP patch tutorial%%
+
+%% Add a download link to any Tutorial Files. To make it a downloadable link, the full directory needs to be entered starting from [Assets/] %%
+	%% E.G. ![[Assets/Guides/Patches/Tutorial - Create an ESP Replacer Patch/MMW_Patches_ESP-Replacer_1.0.zip]]%% 
+
+
+**Scenario:** %% Outline the scenario for the tutorial, summarizing what the problem or goal is, and what the tutorial will teach in order to solve or achieve this %%
+	%% *E.G. `MMW_Patches_ESP-Replacer_1a.esp` adds a house to Caldera. `MMW_Patches_ESP-Replacer_1b.esp` adds a thatch tower to Caldera in the same place - follow the tutorial to create an ESP replacer for `Replacer_1a.esp` which solves the conflict:*%%


### PR DESCRIPTION
Templates can be used by enabling the Templates core plugin in Obsidian. Users need to add local path `Assets/Wiki Templates` to Templates in settings