### PR TITLE
Home: Add contents list for Guides

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -9,11 +9,50 @@ This is the home page of the ***Morrowind Modding Wiki***.
 
 ---
 
-## [[Guides/index|Guides]]
+## [[Guides/index|Guides]] 
+Guides and tutorials covering every aspect of modmaking for Morrowind, organised by category. 
 
-- [[Guides/Animation/index|Animation]]
-- [[Guides/Level Design/index|Level Design]]
-- [[Guides/Patches/index|Patches]]
+>[!info]- Contents 
+> 
+>>[!abstract]- [[Guides/3D Modeling/index|3D Modeling]] 
+>>Guides and Tutorials on 3D Modeling 
+> 
+>>[!abstract]- [[Guides/Animation/index|Animation]] 
+>>Guides and Tutorials on Creating Animations 
+> 
+>>[!abstract]- [[Guides/Cleaning Mods/index|Cleaning Mods]] 
+>>Understanding 'Dirty Edits' and How to Clean Mods 
+>
+>>[!abstract]- [[Guides/Collaborative Modding/index|Collaborative Modding]] 
+>>Tools and Methodologies on Collaborating with Other Mod Authors 
+> 
+>>[!abstract]- [[Guides/Exteriors/index|Exteriors]] 
+>>Designing Exterior Cells and Landscaping 
+> 
+>>[!abstract]- [[Guides/Interiors/index|Interiors]] 
+>>Dungeons and Dwellings - Designing Interior Cells 
+>
+>>[!abstract]- [[Guides/Level Design/index|Level Design]] 
+>>Principles of Video Game Environment and Level Design 
+>
+>>[!abstract]- [[Guides/Leveled Lists/index|Leveled Lists]] 
+>>Leveled Creatures and Items - Working with Leveled Lists 
+>
+>>[!abstract]- [[Guides/Patches/index|Patches]] 
+>>Creating Compatibility - Mod Conflicts and Patches 
+>
+>>[!abstract]- [[Guides/Publishing Mods/index|Publishing Mods]] 
+>>Understanding Permissions, Credits and How to Publish Mods 
+>
+>>[!abstract]- [[Guides/Quest Design/index|Quest Design]] 
+>>Selling a Story - Dialogue, Quest Design and Journal Entries 
+>
+>>[!abstract]- [[Guides/Scripting/index|Scripting]] 
+>>Morrowind Scripting - MWScript, MWSE-Lua and OpenMW-Lua 
+>
+>>[!abstract]- [[Guides/Textures/index|Textures]] 
+>>Creating Textures for Morrowind 
+
 
 ## [[TES3 Construction Set/index|TES3 Construction Set]]
 


### PR DESCRIPTION
Added 'contents' callout under 'Guides' to the homepage, with nested callouts containing each topic under Guides.