### PR TITLE
Add image-adjustments to custom.scss

### DIFF
--- a/Obsidian-CSS-Snippets/snippets/MMW_Image-Adjustments.css
+++ b/Obsidian-CSS-Snippets/snippets/MMW_Image-Adjustments.css
@@ -1,161 +1,3 @@
-@use "./base.scss";
-@use "./variables.scss" as *;
-
-.page-title {
-    height: 200px;
-}
-
-#explorer-ul {
-    max-height: calc(100vh - 400px);
-}
-
-img:not(.Logo) {
-	cursor:zoom-in;}
-
-img:active:not(.Logo) {
-	cursor:zoom-out;
-	display:block;
-	z-index:100;
-	position:fixed;
-    max-height:100%;
-    max-width:100%;
-    height:100%;
-    width:100%;
-    object-fit: contain;
-    margin:0 auto;
-    text-align:center;
-    top: 50%;
-  	transform: translateY(-50%);
-    padding:0;
-    left:0;
-    right:0;
-    bottom:0;
-    background:var(--background-primary);
-}
-
-img {
-  &[alt*="+side"],
-  &[alt*="rside"] {
-    width: 20em;
-    min-width: 50px;
-    float: right;
-    margin: 0;
-    margin-left: 1em;
-
-    @media screen and (max-width: $mobileBreakpoint) {
-      width: 12.5em;
-    }
-  }
-
-  &[alt*="-side"],
-  &[alt*="lside"] {
-    width: 20em;
-    min-width: 50px;
-    float: left;
-    margin: 0;
-    margin-left: 1em;
-
-    @media screen and (max-width: $mobileBreakpoint) {
-      width: 12.5em;
-    }
-  }
-}
-
-/* infobox callout */
-.callout[data-callout="infobox"] {
-  background-color: rgba(80, 120, 180, 0.1);
-  --callout-icon: none;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  float: right;
-  width: 300px;
-  margin: 0px 0px 10px 10px;
-  padding: 5px;
-}
-
-/* mobile breakpoint */
-@media (max-width: 767px) {
-  .callout[data-callout="infobox"] {
-    width: 100%;
-    float: none;
-  }
-}
-
-@media (max-width: 480px) {
-  .callout[data-callout="infobox"] {
-    width:100%;
-    float: none;
-  }
-}
-
-/* stack infoboxes vertically with 'clear' */
-.callout[data-callout="infobox"] {
-  clear: right;
-}
-
-/* Remove Callout Title */
-.callout[data-callout="infobox"] .callout-title {
-  display: none;
-}
-
-
-/* H2 Title */
-.callout[data-callout="infobox"] h2 {
-  margin: auto;
-  max-width: 100%;
-  font-size: 15px;
-  text-align: center;
-  border-radius: 2px;
-  background-color: rgba(255, 255, 255, 0.1);
-  padding: 4px;
-}
-
-/* H3 Title */
-.callout[data-callout="infobox"] h3 {
-  margin: auto;
-  max-width: 100%;
-  font-size: 17px;
-  text-align: center;
-  border-radius: 2px;
-  background-color: rgba(255, 255, 255, 0.1);
-  padding: 4px;
-}
-
-/* Spacing */
-.callout[data-callout="infobox"] p {
-  margin-block-start: 10px;
-  margin-block-end: 0px;
-  width: 100%;
-}
-
-/* Image */
-.callout[data-callout="infobox"] img {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-  max-width: 100%;
-}
-
-/* Table */
-.callout[data-callout="infobox"] table {
-  margin: auto;
-  width: 100%;
-  font-size: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background-color: rgb(30, 30, 30);
-}
-
-.callout[data-callout="infobox"] th {
-  padding-left: 12px; 
-  padding-right: 0px;
-  vertical-align: top;
-}
-
-.callout[data-callout="infobox"] td {
- padding-left: 12px; 
- padding-right: 0px;
- vertical-align: top;
-}
-
 body {
   --image-border-color: var(--background-modifier-border);
   --image-border-width: 1px;
@@ -659,6 +501,71 @@ img[alt~=border],
   object-fit: contain;
 }
 
+/*@settings
+name: Image Adjustments
+id: image-adjustments
+settings:
+    - 
+        id: info-text-SlRvb-img-adj
+        type: info-text
+        title: Image Adjustments by SlRvb
+        description: "[Image Adjustments Snippet How-To Guide](https://publish.obsidian.md/slrvb-docs/ITS+Theme/Image+Adjustments)"
+        markdown: true
+    -
+        title: List Overlap Fix
+        description: Fix list bullets overlapping with images
+        id: img-adj-list
+        type: class-toggle
+        default: true
+    -
+        title: Clear Images
+        description: Push image under/over headings or horizontal lines
+        id: img-adj-clears
+        type: heading
+        level: 1
+        collapsed: true
+    -
+        title: Horizontal Lines
+        description: Push image under/over any horizontal lines
+        id: clear-hr
+        type: class-toggle
+    -
+        title: Headings
+        description: Push image under/over all headings 1-6
+        id: clear-headings
+        type: class-toggle
+    -
+        title: Heading Specific
+        description: Push image under/over some headings and not others
+        id: img-adj-clears-headings
+        type: heading
+        level: 2
+        collapsed: true
+    -
+        title: Header 1
+        id: clear-heading-1
+        type: class-toggle
+    -
+        title: Header 2
+        id: clear-heading-2
+        type: class-toggle
+    -
+        title: Header 3
+        id: clear-heading-3
+        type: class-toggle
+    -
+        title: Header 4
+        id: clear-heading-4
+        type: class-toggle
+    -
+        title: Header 5
+        id: clear-heading-5
+        type: class-toggle
+    -
+        title: Header 6
+        id: clear-heading-6
+        type: class-toggle
+*/
 /*Theme fixes*/
 .img-adj-list :is(ul, ol) {
   display: flow-root;


### PR DESCRIPTION
Add CSS from SIRvb's ITS Theme [Image-Adjustments Snippet](https://publish.obsidian.md/slrvb-docs/ITS+Theme/Image+Adjustments) to `style/custom.scss`. Modified to remove optional settings for Obsidian [Style-Settings](https://github.com/mgmeyers/obsidian-style-settings) plugin as that level of customizability is unnecessary, clutters the css file, and defeats the purpose of maintaining a consistent article format between both Obsidian and Quartz.

Removed `+side` and `-side` image scss by @magicaldave as that functionality is superseded by SIRvb's img-adjustments.