### PR TITLE
Enable HardLineBreaks plugin

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -69,6 +69,7 @@ const config: QuartzConfig = {
       Plugin.CrawlLinks({ markdownLinkResolution: "shortest" }),
       Plugin.Description(),
       Plugin.Latex({ renderEngine: "katex" }),
+      Plugin.HardLineBreaks(),
     ],
     filters: [Plugin.RemoveDrafts()],
     emitters: [


### PR DESCRIPTION
Improves WYSIWYG between Obsidian and Quartz.