### PR TITLE
Fix: Hide Templates folder from Explorer

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -26,7 +26,10 @@ export const defaultContentPageLayout: PageLayout = {
     Component.MobileOnly(Component.Spacer()),
     Component.Search(),
     Component.Darkmode(),
-    Component.DesktopOnly(Component.Explorer({folderClickBehavior: "link"})),
+    Component.DesktopOnly(Component.Explorer({
+      folderClickBehavior: "link", 
+      filterFn: (node) => node.name !== "Templates",
+    })),
   ],
   right: [
     Component.Graph(),
@@ -44,7 +47,10 @@ export const defaultListPageLayout: PageLayout = {
     Component.MobileOnly(Component.Spacer()),
     Component.Search(),
     Component.Darkmode(),
-    Component.DesktopOnly(Component.Explorer({folderClickBehavior: "link"})),
+    Component.DesktopOnly(Component.Explorer({
+      folderClickBehavior: "link", 
+      filterFn: (node) => node.name !== "Templates",
+    })),
   ],
   right: [
     Component.Graph(),


### PR DESCRIPTION
Although hidden from page body, the `Templates` folder previously still showed up in Explorer. This has been fixed by passing a `filterFn:` to `Component.Explorer()` to exclude it.