### PR TITLE
Update: MMW Logo Tweaks

### DIFF
--- a/quartz/components/PageTitle.tsx
+++ b/quartz/components/PageTitle.tsx
@@ -22,10 +22,11 @@ PageTitle.css = `
   margin: 0;
 }
 .Logo {
-max-height: 650px;
-min-height: 50px;
-max-width: 240px;
-min-width: 50px;
+  max-height: 195px;
+  min-height: 50px;
+  max-width: 212px;
+  min-width: 50px;
+  margin: 0;
 }
 `
 

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -2,7 +2,27 @@
 @use "./variables.scss" as *;
 
 .page-title {
-    height: 200px;
+    height: 175px;
+}
+
+/* --- MMW Logo on mobile display --- */
+
+@media screen and (max-width:$mobileBreakpoint) {
+  .Logo {
+    max-height: 185px;
+    min-height: 150px;
+    max-width: 200px;
+    min-width: 150px;
+  }
+  .page-title {
+    height: 150px;
+  }
+  #quartz-body .sidebar.left {
+    margin-top: 0.5rem;
+  }  
+  .sidebar.left .spacer.mobile-only {
+    flex: 0.5 0.5 auto;
+  }
 }
 
 #explorer-ul {


### PR DESCRIPTION
- MMW Logo on mobile is now smaller, so it no longer pushes the search bar off-screen to the right.
- MMW Logo on desktop reduced to 212px width, the same width as the explorer. Now it no longer stretches out to the right of the explorer and is instead vertically in-line with it