### PR TITLE
Feature: Add option to hide transclusion styling using `|clean`

### DIFF
--- a/content/.obsidian/snippets/MMW_Transclusion_Adjustments.css
+++ b/content/.obsidian/snippets/MMW_Transclusion_Adjustments.css
@@ -1,0 +1,6 @@
+/*Transclusions*/
+
+.internal-embed[alt$=clean].is-loaded:not(.image-embed) {
+    --embed-padding: 0;
+    border: none;
+}

--- a/content/.obsidian/snippets/MMW_Transclusion_Adjustments.css
+++ b/content/.obsidian/snippets/MMW_Transclusion_Adjustments.css
@@ -1,6 +1,20 @@
 /*Transclusions*/
 
-.internal-embed[alt$=clean].is-loaded:not(.image-embed) {
+.internal-embed[alt~=clean].is-loaded:not(.image-embed) {
     --embed-padding: 0;
     border: none;
 }
+
+.internal-embed[alt~=right] {
+    float: right;
+    margin-left: 0.5em;
+  }
+  
+  .internal-embed[alt~=left] {
+    float: left;
+    margin-right: 0.5em;
+  }
+  
+  :not(.lp-embed-float) .is-live-preview .internal-embed:is([alt~=right], [alt~=left]) {
+    float: unset;
+  }

--- a/content/contributing/custom-formatting-features.md
+++ b/content/contributing/custom-formatting-features.md
@@ -238,3 +238,30 @@ A wiki-style infobox displayed in the top right of an article to summarize data 
 > | Row | Row |
 > | Row | Row |
 ```
+
+---
+
+## Hide Embed ('Transclusion') Styling
+
+**Syntax:**
+
+```
+![[Embedded Note|attribute]]
+![[intereting-note-title|clean]]
+```
+
+| Attribute | Description                        |
+| --------- | ---------------------------------- |
+| `clean`   | Removes border to hide embed style |
+
+When embedding content from one note within another note, the default border styling can be hidden by adding '`|clean]]`' at the end of the wikilink, in order to make the embed appear seamlessly as a part of the page it is embedded in. ^4beb5b
+
+This allows for [[redundancy]] within the wiki, wherein an important piece of data (such as a table or a contents list), which must appear on multiple pages, can be stored in just one note. When updates are made to the data, only the original note needs to be edited; all pages where that data has been embedded will be updated automatically. 
+
+This is the same principle as [Wikipedia 'Templates'](https://en.wikipedia.org/wiki/Wikipedia:Templates). However, it has been renamed because ['Templates' in Obsidian serve a different function](https://help.obsidian.md/Plugins/Templates).
+
+> [!example] This is a standard transclusion:
+> ![[custom-formatting-features#^4beb5b]]
+
+> [!example] This is a 'clean' transclusion:
+> ![[custom-formatting-features#^4beb5b|clean]]

--- a/content/contributing/custom-formatting-features.md
+++ b/content/contributing/custom-formatting-features.md
@@ -241,27 +241,47 @@ A wiki-style infobox displayed in the top right of an article to summarize data 
 
 ---
 
-## Hide Embed ('Transclusion') Styling
+## Embed Adjustments
 
-**Syntax:**
+Adjustments for Obsidian [embedded files](https://help.obsidian.md/Linking+notes+and+files/Embed+files), otherwise known as 'transclusions'
 
-```
-![[Embedded Note|attribute]]
-![[intereting-note-title|clean]]
+```markdown title="syntax"
+![[Embedded Note|attribute attribute]]
+
+![[intereting-note-title|clean right]]
 ```
 
 | Attribute | Description                        |
 | --------- | ---------------------------------- |
 | `clean`   | Removes border to hide embed style |
+| `left`    | Float                              |
+| `right`   | Floats embed to the right          |
 
-When embedding content from one note within another note, the default border styling can be hidden by adding '`|clean]]`' at the end of the wikilink, in order to make the embed appear seamlessly as a part of the page it is embedded in. ^4beb5b
+### Hide Embed Styling
 
-This allows for [[redundancy]] within the wiki, wherein an important piece of data (such as a table or a contents list), which must appear on multiple pages, can be stored in just one note. When updates are made to the data, only the original note needs to be edited; all pages where that data has been embedded will be updated automatically. 
+You can hide the borders of embedded notes and blocks by adding '`|clean]]`' to the wikilink's alias.
+^4beb5b
 
-This is the same principle as [Wikipedia 'Templates'](https://en.wikipedia.org/wiki/Wikipedia:Templates). However, it has been renamed because ['Templates' in Obsidian serve a different function](https://help.obsidian.md/Plugins/Templates).
+This allows the embed to appear seamlessly as a part of the page it is embedded in. 
 
-> [!example] This is a standard transclusion:
-> ![[custom-formatting-features#^4beb5b]]
+> [!column|2 flex clean no-t]
+> > [!example] This is a standard transclusion:
+> > ![[custom-formatting-features#^4beb5b]]
+>
+> > [!example] This is a 'clean' transclusion:
+> > ![[custom-formatting-features#^4beb5b|clean]]
 
-> [!example] This is a 'clean' transclusion:
-> ![[custom-formatting-features#^4beb5b|clean]]
+> [!warning] Embedding block links which float left or right
+> You must add a `left` or `right` attribute to embeds if the embedded content itself already floats left or right.
+> 
+> **Example:**
+> - The [[custom-formatting-features#Infobox|infobox callout]] already floats right. To embed it in another page, add `|right` to the embed wikilink's alias.
+> 
+> This prevents the embed from taking up 100% of the page-width, instead of wrapping around other content
+
+### Float Embed Left or Right
+
+Embeds can be made to float to the left or right of a page by adding `|left` or `|right` to the embed wikilink's alias. ^cb5c00
+
+As well as being a stylistic choice to move supplementary content outside of the main flow of the text, it is also necessary when embedding a block which contains an element with a float property already stipulated (e.g., an infobox callout).
+

--- a/content/contributing/manual-of-style/content-guidelines.md
+++ b/content/contributing/manual-of-style/content-guidelines.md
@@ -8,7 +8,7 @@ aliases:
   - Content Guidelines
 ---
 
-![[contributing/manual-of-style/index#^3085e6|Manual of Style - 36 Sermons of MMW]]
+![[contributing/manual-of-style/index#^3085e6|Manual of Style - 36 Sermons of MMW clean]]
 
 ## Writing Style
 
@@ -36,3 +36,9 @@ TO-DO
 	- videos
 - downloads
 - first-person tone
+
+## Transclusions
+
+This allows for [[redundancy]] within the wiki, wherein an important piece of data (such as a table or a contents list), which must appear on multiple pages, can be stored in just one note. When updates are made to the data, only the original note needs to be edited; all pages where that data has been embedded will be updated automatically. 
+
+This is the same principle as [Wikipedia 'Templates'](https://en.wikipedia.org/wiki/Wikipedia:Templates). However, it has been renamed because ['Templates' in Obsidian serve a different function](https://help.obsidian.md/Plugins/Templates).

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1,5 +1,7 @@
 @use "./base.scss";
 @use "./variables.scss" as *;
+/* -- MMW SCSS Modules -- */
+@use "./custom/transclusions.scss";
 
 .page-title {
     height: 175px;

--- a/quartz/styles/custom/transclusions.scss
+++ b/quartz/styles/custom/transclusions.scss
@@ -1,0 +1,11 @@
+@use "../base.scss";
+@use "../variables.scss" as *;
+
+.transclude[data-embed-alias~=clean] {
+    border-left: none;
+    padding-left: 0;
+}
+
+.transclude[data-embed-alias~=clean] > .transclude-src {
+    display: none;
+}

--- a/quartz/styles/custom/transclusions.scss
+++ b/quartz/styles/custom/transclusions.scss
@@ -1,11 +1,11 @@
 @use "../base.scss";
 @use "../variables.scss" as *;
 
-.transclude[data-embed-alias$=clean] {
+.transclude[data-embed-alias~=clean] {
     border-left: none;
     padding-left: 0;
 }
 
-.transclude[data-embed-alias$=clean] > .transclude-src {
+.transclude[data-embed-alias~=clean] > .transclude-src {
     display: none;
 }

--- a/quartz/styles/custom/transclusions.scss
+++ b/quartz/styles/custom/transclusions.scss
@@ -1,11 +1,11 @@
 @use "../base.scss";
 @use "../variables.scss" as *;
 
-.transclude[data-embed-alias~=clean] {
+.transclude[data-embed-alias$=clean] {
     border-left: none;
     padding-left: 0;
 }
 
-.transclude[data-embed-alias~=clean] > .transclude-src {
+.transclude[data-embed-alias$=clean] > .transclude-src {
     display: none;
 }


### PR DESCRIPTION
Adding the alias `|clean` to a transclusion hides the blockquote styling.

Additionally, added `|left` and `|right` alias to float embeds left or right. This is required if embedding a block (such as an infobox callout) which already has a float property, because in Obsidian the `<span>` containing the embed will otherwise take up 100% page-width and prevent the floating embed from actually wrapping around other content. Quartz is unaffected as it handles transclusions differently, so the `left` and `right` aliases are not defined in the Quartz scss. This is purely a WYSIWYG compromise with Obsidian.

This update also marks a change in approach for creating custom scss for Quartz. Because the `styles/custom.scss` file has bloated in size and is becoming more difficult to navigate, I opted to utilise scss modules. The new Quartz css for transclusions can be found in `styles/custom/transclusions.scss`, which is imported as a module into `custom.scss`.

Closes #47