### PR TITLE
Fix: page modified dates are incorrect

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -17,7 +17,7 @@ const config: QuartzConfig = {
     locale: "en-US",
     baseUrl: "morrowind-modding.github.io",
     ignorePatterns: ["private", "**/templates/", ".obsidian"],
-    defaultDateType: "created",
+    defaultDateType: "modified",
     theme: {
       fontOrigin: "googleFonts",
       cdnCaching: true,
@@ -56,7 +56,7 @@ const config: QuartzConfig = {
     transformers: [
       Plugin.FrontMatter(),
       Plugin.CreatedModifiedDate({
-        priority: ["frontmatter", "filesystem"],
+        priority: ["git", "frontmatter", "filesystem"],
       }),
       Plugin.SyntaxHighlighting({
         theme: {

--- a/quartz/components/PageList.tsx
+++ b/quartz/components/PageList.tsx
@@ -25,16 +25,16 @@ export function byDateAndAlphabetical(
   }
 }
 
-export function byAlphabetical(
-  cfg: GlobalConfiguration,
-): (f1: QuartzPluginData, f2: QuartzPluginData) => number {
-  return (f1, f2) => {
-    // sort lexographically by title
-    const f1Title = f1.frontmatter?.title.toLowerCase() ?? ""
-    const f2Title = f2.frontmatter?.title.toLowerCase() ?? ""
-    return f1Title.localeCompare(f2Title)
-  }
-}
+// export function byAlphabetical(
+//   cfg: GlobalConfiguration,
+// ): (f1: QuartzPluginData, f2: QuartzPluginData) => number {
+//   return (f1, f2) => {
+//     // sort lexographically by title
+//     const f1Title = f1.frontmatter?.title.toLowerCase() ?? ""
+//     const f2Title = f2.frontmatter?.title.toLowerCase() ?? ""
+//     return f1Title.localeCompare(f2Title)
+//   }
+// }
 
 type Props = {
   limit?: number
@@ -42,7 +42,7 @@ type Props = {
 } & QuartzComponentProps
 
 export const PageList: QuartzComponent = ({ cfg, fileData, allFiles, limit, sort }: Props) => {
-  const sorter = sort ?? byAlphabetical(cfg)
+  const sorter = sort ?? byDateAndAlphabetical(cfg)
   let list = allFiles.sort(sorter)
   if (limit) {
     list = list.slice(0, limit)
@@ -60,7 +60,8 @@ export const PageList: QuartzComponent = ({ cfg, fileData, allFiles, limit, sort
             <div class="section">
               <div>
                 {page.dates && (
-                  <p>
+                  <p class="meta">
+                    <Date date={getDate(cfg, page)!} locale={cfg.locale} />
                   </p>
                 )}
               </div>


### PR DESCRIPTION
Edits to `quartz.config.ts` and [CreatedModifiedDate](https://quartz.jzhao.xyz/plugins/CreatedModifiedDate) plugin to hopefully fix page modified dates being incorrect (they show date of last site build, rather than individual file modified dates)